### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,13 @@
+name: CI
+
+on:
+  - push
+  - pull_request
+  - workflow_dispatch
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nextstrain/.github/actions/shellcheck@master


### PR DESCRIPTION
Add minimum CI workflow that currently only runs a shellcheck job like the shellcheck workflow in the ncov-ingest repo¹.

We may choose to add more tests in the future, but shellcheck is enough for now to catch errors in bash scripts. This will be helpful as I centralize the scripts that have diverged in the various ingest workflows.

¹ https://github.com/nextstrain/ncov-ingest/blob/6fd5a9b1d87e59fab35173dbedf376632154943b/.github/workflows/shellcheck.yml