### PR TITLE
snakemake/remote_files: Add minimum version check for Snakemake

### DIFF
--- a/snakemake/remote_files.smk
+++ b/snakemake/remote_files.smk
@@ -9,6 +9,10 @@ to check these ourselves to improve UX here.
 """
 
 from urllib.parse import urlparse
+from snakemake.utils import min_version
+
+# Minimum Snakemake version needed for the storage plugins
+min_version("8.0.0")
 
 # Keep a list of known public buckets, which we'll allow uncredentialled (unsigned) access to
 # We could make this config-definable in the future


### PR DESCRIPTION
### Description of proposed changes

Add `min_version` in the shared `remote_files.smk` so that individual workflows  that import it don't have to remember to add the version check. 

Based on feedback from @victorlin in mpox
<https://github.com/nextstrain/mpox/pull/339#discussion_r2389612544>

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [ ] Checks pass
- [ ] If adding a script, add an entry for it in the README.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
