### PR TITLE
Add config functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Potential Nextstrain CLI scripts
 
 Snakemake workflow functions that are shared across many pathogen workflows that don’t really belong in any of our existing tools.
 
-- [config.smk](snakemake/config.smk) - Shared functions for parsing workflow configs.
+- [config.smk](snakemake/config.smk) - Shared functions for handling workflow configs.
 - [remote_files.smk](snakemake/remote_files.smk) - Exposes the `path_or_url` function which will use Snakemake's storage plugins to download/upload files to remote providers as needed.
 
 

--- a/snakemake/config.smk
+++ b/snakemake/config.smk
@@ -1,8 +1,10 @@
 """
-Shared functions to be used within a Snakemake workflow for parsing
+Shared functions to be used within a Snakemake workflow for handling
 workflow configs.
 """
-import os.path
+import os
+import sys
+import yaml
 from collections.abc import Callable
 from snakemake.io import Wildcards
 from typing import Optional
@@ -75,3 +77,15 @@ def resolve_config_path(path: str, defaults_dir: Optional[str] = None) -> Callab
             """), " " * 4))
 
     return _resolve_config_path
+
+
+def write_config(path):
+    """
+    Write Snakemake's 'config' variable to a file.
+    """
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    with open(path, 'w') as f:
+        yaml.dump(config, f, sort_keys=False)
+
+    print(f"Saved current run config to {path!r}.", file=sys.stderr)

--- a/snakemake/config.smk
+++ b/snakemake/config.smk
@@ -83,6 +83,8 @@ def write_config(path):
     """
     Write Snakemake's 'config' variable to a file.
     """
+    global config
+
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
     with open(path, 'w') as f:

--- a/snakemake/config.smk
+++ b/snakemake/config.smk
@@ -15,6 +15,74 @@ class InvalidConfigError(Exception):
     pass
 
 
+def resolve_filepaths(filepaths):
+    """
+    Update filepaths in-place by passing them through resolve_config_path().
+
+    `filepaths` must be a list of key tuples representing filepaths in config.
+    Use "*" as a a key-expansion placeholder: it means "iterate over all keys at
+    this level".
+    """
+    global config
+
+    for keys in filepaths:
+        _traverse(config, keys, traversed_keys=[])
+
+
+def _traverse(config_section, keys, traversed_keys):
+    """
+    Recursively walk through the config following a list of keys.
+
+    When the final key is reached, the value is updated in place.
+    """
+    key = keys[0]
+    remaining_keys = keys[1:]
+
+    if key == "*":
+        for key in config_section:
+            if len(remaining_keys) == 0:
+                _update_value_inplace(config_section, key, traversed_keys=traversed_keys + [f'* ({key})'])
+            else:
+                if isinstance(config_section[key], dict):
+                    _traverse(config_section[key], remaining_keys, traversed_keys=traversed_keys + [f'* ({key})'])
+                else:
+                    # Value for key is not a dict
+                    # Leave as-is - this may be valid config value.
+                    continue
+    elif key in config_section:
+        if len(remaining_keys) == 0:
+            _update_value_inplace(config_section, key, traversed_keys=traversed_keys + [key])
+        else:
+            _traverse(config_section[key], remaining_keys, traversed_keys=traversed_keys + [key])
+    else:
+        # Key not present in config section
+        # Ignore - this may be an optional parameter.
+        return
+
+
+def _update_value_inplace(config_section, key, traversed_keys):
+    """
+    Update the value at 'config_section[key]' with resolve_config_path().
+
+    resolve_config_path() returns a callable which has the ability to replace
+    {var} in filepath strings. This was originally designed to support Snakemake
+    wildcards, but those are not applicable here since this code is not running
+    in the context of a Snakemake rule. It is unused here - the callable is
+    given an empty dict.
+    """
+    value = config_section[key]
+    traversed = ' → '.join(repr(key) for key in traversed_keys)
+    if isinstance(value, list):
+        for path in value:
+            assert isinstance(path, str), f"ERROR: Expected string but got {type(path).__name__} at {traversed}."
+        new_value = [resolve_config_path(path)({}) for path in value]
+    else:
+        assert isinstance(value, str), f"ERROR: Expected string but got {type(value).__name__} at {traversed}."
+        new_value = resolve_config_path(value)({})
+    config_section[key] = new_value
+    print(f"Resolved {value!r} to {new_value!r}.", file=sys.stderr)
+
+
 def resolve_config_path(path: str, defaults_dir: Optional[str] = None) -> Callable[[Wildcards], str]:
     """
     Resolve a relative *path* given in a configuration value. Will always try to


### PR DESCRIPTION
### Description of proposed changes

Adds config-related functions that are planned for reuse across across pathogen repos.

### Related issue(s)

`write_config()` is for https://github.com/nextstrain/pathogen-repo-guide/issues/18
`resolve_filepaths()` is for https://github.com/nextstrain/public/issues/23

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [ ] Checks pass
- [x] ~If adding a script, add an entry for it in the README.~
- [ ] TBD: PRs on WNV and measles to use these shared functions

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
