### PR TITLE
Disable aliases in dumped config

### DIFF
--- a/snakemake/config.smk
+++ b/snakemake/config.smk
@@ -156,6 +156,11 @@ def write_config(path):
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
     with open(path, 'w') as f:
-        yaml.dump(config, f, sort_keys=False)
+        yaml.dump(config, f, sort_keys=False, Dumper=NoAliasDumper)
 
     print(f"Saved current run config to {path!r}.", file=sys.stderr)
+
+
+class NoAliasDumper(yaml.SafeDumper):
+    def ignore_aliases(self, data):
+        return True


### PR DESCRIPTION
### Description of proposed changes

Dumping the config with fully expanded contents is better for debugging and potential reuse.

Workaround adapted from https://stackoverflow.com/a/66853182

### Related issue(s)

- Follow-up to https://github.com/nextstrain/rsv/pull/103#discussion_r2408551444
- `ignore_aliases` workaround necessary for https://github.com/yaml/pyyaml/issues/103

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Tested locally
- [x] Checks pass
- [x] ~If adding a script, add an entry for it in the README.~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
