### PR TITLE
config: Set AUGUR_SEARCH_PATHS

### DIFF
--- a/snakemake/config.smk
+++ b/snakemake/config.smk
@@ -34,6 +34,10 @@ else:
         Path(workflow.basedir),
     ]
 
+    # This should work for majority of workflows, but we could consider doing a
+    # more thorough search for the nextstrain-pathogen.yaml. This would likely
+    # replicate how CLI searches for the root.¹
+    # ¹ <https://github.com/nextstrain/cli/blob/d5e184c5/nextstrain/cli/command/build.py#L413-L420>
     repo_root = Path(workflow.basedir) / ".."
     if (repo_root / "nextstrain-pathogen.yaml").is_file():
         search_paths.extend([


### PR DESCRIPTION
### Description of proposed changes

To be used by various Augur commands and pathogen workflows, starting with augur subsample in the measles repo.

### Review threads

- [How to customize `AUGUR_SEARCH_PATHS`?](https://github.com/nextstrain/shared/pull/68#discussion_r2744287096)
- [What should the search paths be?](https://github.com/nextstrain/shared/pull/68#discussion_r2744294994)
- [How could `AUGUR_SEARCH_PATHS` be used in `resolve_config_path()`?](https://github.com/nextstrain/shared/pull/68#discussion_r2748687392)
- [Do a more thorough search for pathogen repo root?](https://github.com/nextstrain/shared/pull/68#discussion_r2765578988)

### Related issue(s)

Used in https://github.com/nextstrain/measles/pull/90

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] ~Checks pass~ N/A
- [x] ~If adding a script, add an entry for it in the README.~ N/A

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
