### PR TITLE
Remove import of `snakemake.io.Wildcards`

### DIFF
--- a/snakemake/config.smk
+++ b/snakemake/config.smk
@@ -6,7 +6,6 @@ import os
 import sys
 import yaml
 from collections.abc import Callable
-from snakemake.io import Wildcards
 from typing import Optional
 from textwrap import dedent, indent
 
@@ -54,7 +53,7 @@ class InvalidConfigError(Exception):
     pass
 
 
-def resolve_config_path(path: str, defaults_dir: Optional[str] = None) -> Callable[[Wildcards], str]:
+def resolve_config_path(path: str, defaults_dir: Optional[str] = None) -> Callable:
     """
     Resolve a relative *path* given in a configuration value. Will always try to
     resolve *path* after expanding wildcards with Snakemake's `expand` functionality.


### PR DESCRIPTION

### Description of proposed changes

`Wildcards` has been moved in Snakemake 9.17.0¹ and again in 9.18.0.² The import was non-functional and for typing purposes only, so just remove the import and not rely on Snakemake internals as discussed
in <https://github.com/nextstrain/public/issues/39>

¹ <https://github.com/snakemake/snakemake/commit/ffb19e72a2162bb7c1b63eeb1d0ea99a65ef51a3> 
² <https://github.com/snakemake/snakemake/commit/2ed2c23dd8e5cb40ef4a5ebfe8d40a6e3646d5f6>


### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [x] ~If adding a script, add an entry for it in the README.~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
