### PR TITLE
scripts/notify-on-record-change: only support zst

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Scripts for supporting workflow automation that don’t really belong in any of 
 - [notify-on-job-fail](scripts/notify-on-job-fail) - Send Slack message with details about failed workflow job on GitHub Actions and/or AWS Batch
 - [notify-on-job-start](scripts/notify-on-job-start) - Send Slack message with details about workflow job on GitHub Actions and/or AWS Batch
 - [notify-on-record-change](scripts/notify-on-record-change) - Send Slack message with details about line count changes for a file compared to an S3 object's metadata `recordcount`.
-  If the S3 object's metadata does not have `recordcount`, then will attempt to download S3 object to count lines locally, which only supports `xz` compressed S3 objects.
+  If the S3 object's metadata does not have `recordcount`, then will attempt to download S3 object to count lines locally, which only supports `zst` compressed S3 objects.
 - [notify-slack](scripts/notify-slack) - Send message or file to Slack
 - [s3-object-exists](scripts/s3-object-exists) - Used to prevent 404 errors during S3 file comparisons in the notify-* scripts
 - [trigger](scripts/trigger) - Triggers downstream GitHub Actions via the GitHub API using repository_dispatch events.

--- a/scripts/notify-on-record-change
+++ b/scripts/notify-on-record-change
@@ -24,7 +24,7 @@ dst_record_count="$(aws s3api head-object --bucket "$bucket" --key "$key" --quer
 if [[ -z "$dst_record_count" ]]; then
   # This object doesn't have the record count stored as metadata
   # We have to download it and count the lines locally
-  dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | xz -T0 -dcfq))"
+  dst_record_count="$(wc -l < <(aws s3 cp --no-progress "$dst" - | zstd -T0 -dcq))"
 fi
 
 added_records="$(( src_record_count - dst_record_count ))"


### PR DESCRIPTION
### Description of proposed changes

Prompted by <https://github.com/nextstrain/ncov-ingest/pull/528#discussion_r3365443778>

Except ncov-ingest, all other uses of the script actually uses zst files. We've just never had any issues because all files have the stored record count as metadata.

### Related issue(s)

Related to https://github.com/nextstrain/ncov-ingest/issues/502

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [ ] ~If adding a script, add an entry for it in the README.~
- [x] Post-merge: follow-up that [downstream repos are updated](https://github.com/nextstrain/shared/pull/73#issuecomment-4290435876)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
