### PR TITLE
Check Augur version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Snakemake workflow functions that are shared across many pathogen workflows that
 
 - [config.smk](snakemake/config.smk) - Shared functions for handling workflow configs.
 - [remote_files.smk](snakemake/remote_files.smk) - Exposes the `path_or_url` function which will use Snakemake's storage plugins to download/upload files to remote providers as needed.
+- [dependencies.py](./snakemake/dependencies.py) - Helper functions for checking dependency versions.
 
 
 ## Software requirements

--- a/snakemake/config.smk
+++ b/snakemake/config.smk
@@ -2,6 +2,9 @@
 Shared functions to be used within a Snakemake workflow for handling
 workflow configs.
 """
+from dependencies import set_min_augur_version
+set_min_augur_version("34.1.0")
+
 import os
 import sys
 import yaml

--- a/snakemake/dependencies.py
+++ b/snakemake/dependencies.py
@@ -1,0 +1,10 @@
+from packaging import version
+from augur.__version__ import __version__ as augur_version
+import sys
+
+
+def set_min_augur_version(min_augur_version: str):
+    if version.parse(augur_version) < version.parse(min_augur_version):
+      print("This pipeline needs a newer version of augur than you currently have...")
+      print(f"Current augur version: {augur_version}. Minimum required: {min_augur_version}")
+      sys.exit(1)


### PR DESCRIPTION
### Description of proposed changes

augur.config.resolve_filepath is only available starting with version 34.1.0.

Added the version checking code¹ to a new file for future similar usage.

¹ copied from mpox with some modifications

### Related issue(s)

Follow-up to https://github.com/nextstrain/shared/pull/78#discussion_r3633595955

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [x] Tested locally by copying the changes into measles repo, using an older docker image, and running `--dry-run`. Error:

	```
	This pipeline needs a newer version of augur than you currently have...
	Current augur version: 34.0.0. Minimum required: 34.1.0
	```

- [x] If adding a script, add an entry for it in the README.

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
