### PR TITLE
cloudfront-invalidate: Guard against null `Aliases.Items`

### DIFF
--- a/scripts/cloudfront-invalidate
+++ b/scripts/cloudfront-invalidate
@@ -11,7 +11,7 @@ main() {
     echo "-> Finding CloudFront distribution"
     distribution=$(
         aws cloudfront list-distributions \
-            --query "DistributionList.Items[?contains(Aliases.Items, \`$domain\`)] | [0].Id" \
+            --query "DistributionList.Items[?contains(not_null(Aliases.Items, ''), \`$domain\`)] | [0].Id" \
             --output text
     )
 


### PR DESCRIPTION
### Description of proposed changes

Prevent error where query fails because a disabled CloudFront distribution does not have any Aliases.

### Related issue(s)

Resolves https://github.com/nextstrain/shared/issues/83

### Checklist

<!-- Make sure checks are successful at the bottom of the PR. -->

- [x] Checks pass
- [ ] ~If adding a script, add an entry for it in the README.~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
